### PR TITLE
画面が回転した時にレイアウトが崩れる点を修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:label="@string/app_name"
             android:theme="@style/Theme.Calculator">
             <intent-filter>


### PR DESCRIPTION
## Issue
- close #6

## Overview (Required)

- AndroidManifestのscreenOrientationをportraitに固定することで、対応。

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />